### PR TITLE
update bosh create release to use go bosh instead of ruby bosh

### DIFF
--- a/example-release/build-release-tarball
+++ b/example-release/build-release-tarball
@@ -18,7 +18,7 @@ rm -f ${RELEASES_DIR}/example-release/*.tgz
 
 release_yml=$(ls ${RELEASES_DIR}/example-release/example-release-*.yml | sort -t '-' -k 4 -g | tail -1)
 echo "creating release from ${release_yml}"
-bundle exec bosh create release "${release_yml}" --force --with-tarball
+bundle exec bosh create-release "${release_yml}" --force --tarball=${RELEASES_DIR}/example-release/example-release-$$.tgz
 
 release_tgz=$(ls ${RELEASES_DIR}/example-release/example-release-*.tgz | sort -t '-' -k 4 -g | tail -1)
 if [[ ! -f ${release_tgz} ]]; then


### PR DESCRIPTION
We are going to use the `bosh` CLI like it is 2019!