### PR TITLE
Add job to test BOSH DNS healthiness during upgrade

### DIFF
--- a/example-product/metadata/example-product.yml.erb
+++ b/example-product/metadata/example-product.yml.erb
@@ -673,6 +673,8 @@ job_types:
         release: example-release
       - name: example_colocated_errand
         release: example-release
+      - name: dns_tester_source
+        release: example-release
     release: example-release
     static_ip: 1
     dynamic_ip: 0
@@ -1016,6 +1018,8 @@ job_types:
     resource_label: No Operation
     templates:
       - name: no_op
+        release: example-release
+      - name: dns_tester_dest
         release: example-release
     static_ip: 0
     dynamic_ip: 1

--- a/example-release/jobs/dns_tester_dest/monit
+++ b/example-release/jobs/dns_tester_dest/monit
@@ -1,0 +1,5 @@
+check process dns_tester_dest
+  with pidfile /var/vcap/sys/run/dns_tester_dest/pidfile
+  start program "/var/vcap/jobs/dns_tester_dest/bin/ctl start"
+  stop program "/var/vcap/jobs/dns_tester_dest/bin/ctl stop"
+  group vcap

--- a/example-release/jobs/dns_tester_dest/spec
+++ b/example-release/jobs/dns_tester_dest/spec
@@ -1,0 +1,12 @@
+---
+name: dns_tester_dest
+templates:
+  ctl.erb: bin/ctl
+
+packages: []
+
+provides:
+  - name: dest_dns_job 
+    type: dns_job
+
+properties: {}

--- a/example-release/jobs/dns_tester_dest/templates/ctl.erb
+++ b/example-release/jobs/dns_tester_dest/templates/ctl.erb
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+RUN_DIR=/var/vcap/sys/run/dns_tester_dest
+PIDFILE=${RUN_DIR}/pidfile
+
+case $1 in
+  start)
+    mkdir -p $RUN_DIR
+
+    echo '1' > $PIDFILE
+    ;;
+
+  stop)
+    rm -f $PIDFILE
+    ;;
+
+  *)
+    echo "Usage: ctl {start|stop}"
+  ;;
+
+esac

--- a/example-release/jobs/dns_tester_source/monit
+++ b/example-release/jobs/dns_tester_source/monit
@@ -1,0 +1,5 @@
+check process dns_tester_source
+  with pidfile /var/vcap/sys/run/dns_tester_source/pidfile
+  start program "/var/vcap/jobs/dns_tester_source/bin/ctl start"
+  stop program "/var/vcap/jobs/dns_tester_source/bin/ctl stop"
+  group vcap

--- a/example-release/jobs/dns_tester_source/spec
+++ b/example-release/jobs/dns_tester_source/spec
@@ -1,0 +1,13 @@
+---
+name: dns_tester_source 
+templates:
+  ctl.erb: bin/ctl
+
+packages: []
+
+consumes:
+  - name: dest_dns_job
+    type: dns_job
+    optional: true
+
+properties: {}

--- a/example-release/jobs/dns_tester_source/templates/ctl.erb
+++ b/example-release/jobs/dns_tester_source/templates/ctl.erb
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+RUN_DIR=/var/vcap/sys/run/dns_tester_source
+PIDFILE=${RUN_DIR}/pidfile
+LAST_LINK_LENGTH_FILE=/var/vcap/store/dns_tester_link_length
+LOG_FILE=/var/vcap/sys/log/dns_tester_source/dns_tester.log
+LINK_LENGTH=<%= link('dest_dns_job').instances.length %>
+HEALTHY_DNS_ADDR="<%= link('dest_dns_job').address(status: 'healthy', initial_health_check: "synchronous") %>"
+
+
+case $1 in
+  start)
+    mkdir -p $RUN_DIR
+
+    echo "========= STARTING UP ========" >> $LOG_FILE
+    date >> $LOG_FILE
+    echo "Total number of expected destination nodes: $LINK_LENGTH" >> $LOG_FILE
+
+    if [ -f $LAST_LINK_LENGTH_FILE ]; then
+      LAST_LINK_LENGTH=$(cat $LAST_LINK_LENGTH_FILE) 
+      echo "Found $LAST_LINK_LENGTH destination nodes deployed last time from $LAST_LINK_LENGTH_FILE" >> $LOG_FILE
+    else
+      echo "No previous link length file ($LAST_LINK_LENGTH_FILE), must be first deploy. Starting safely." >> $LOG_FILE
+      echo $LINK_LENGTH > $LAST_LINK_LENGTH_FILE
+      echo '1' > $PIDFILE
+      exit 0
+    fi 
+
+    echo $LINK_LENGTH > $LAST_LINK_LENGTH_FILE
+
+    if [ "$LAST_LINK_LENGTH" -eq "0" ]; then
+      echo "No previously deployed destination nodes to test. Starting safely." >> $LOG_FILE
+      echo '1' > $PIDFILE
+      exit 0
+    fi
+
+    if [ "$LINK_LENGTH" -eq "0" ]; then
+      echo "No destination nodes for this future deploy, assuming you want the test disabled. Starting safely." >> $LOG_FILE
+      echo '1' > $PIDFILE
+      exit 0
+    fi
+
+    echo "Resolving $HEALTHY_DNS_ADDR in order to see how many healthy nodes exist" >> $LOG_FILE
+    NUMBER_OF_HEALTHY_NODES=$(host $HEALTHY_DNS_ADDR | wc -l)
+    echo "  Found $NUMBER_OF_HEALTHY_NODES entries" >> $LOG_FILE
+
+    if [ "$NUMBER_OF_HEALTHY_NODES" -lt "$LAST_LINK_LENGTH" ]; then
+      echo "No healthy destination nodes (or fewer than expected), even though they've been deployed previously. Either those VMs are misbehaving, or BOSH DNS is not able to determine healthiness. Failing to start!" >> $LOG_FILE
+      rm -f $PIDFILE
+      exit 0
+    fi
+
+    echo "Deployed nodes and healthy nodes are equal. Starting safely." >> $LOG_FILE
+    echo '1' > $PIDFILE
+
+    ;;
+
+  stop)
+    echo "========= STOPPING ========" >> $LOG_FILE
+    date >> $LOG_FILE
+    rm -f $PIDFILE
+    ;;
+
+  *)
+    echo "Usage: ctl {start|stop}"
+  ;;
+
+esac


### PR DESCRIPTION
A fairly simple "source" and "destination" job that can be linked
together with BOSH DNS provides the ability to detect disfunctional
BOSH DNS deployments, particularly around healthiness during upgrades.

The source job is attached to web_server, and the destinations are the no_op.
Initial deploys skip the tests, since no_op isn't deployed until after web_server,
but on subsequent deploys the testing system
deployed on the source validates that the destination nodes still appear healthy.
The advantage of pinging a "later deployed" node is that you can guarentee that
an older version of DNS can interoperate with a newer version of DNS, especially
around the healthiness features.